### PR TITLE
Support publishing with provenance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # Setup .npmrc file to publish to npm
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
-        node-version: '12.x'
+        node-version: '22.x'
         registry-url: 'https://registry.npmjs.org'
-    - run: npm install
-    - run: npm publish
+    - run: npm ci
+    - run: npm publish --provenance
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR updates GitHub Actions to use the latest versions of `actions/checkout`, `actions/setup-node`, and Node.js `22.x`. It replaces `npm install` with `npm ci` for reproducible installs and adds `--provenance` to `npm publish` for enhanced supply chain security. More on NPM provenance [here](https://docs.npmjs.com/generating-provenance-statements).